### PR TITLE
feat: CalendarItem Controller 응답 포맷을 ResponseEntity 객체와 커스텀

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/yoda/accountProject/calendar/controller/CalendarController.java
+++ b/src/main/java/com/yoda/accountProject/calendar/controller/CalendarController.java
@@ -6,22 +6,22 @@ import com.yoda.accountProject.calendar.dto.CalendarResponseDto;
 import com.yoda.accountProject.calendar.dto.CalendarUpdateDto;
 import com.yoda.accountProject.calendar.service.CalendarService;
 import com.yoda.accountProject.system.common.response.ResponseData;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
-
 @RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class CalendarController {
 
     private final CalendarService calendarService;
 
     @GetMapping("/home")
-    public ResponseEntity<ResponseData<CalendarFinalResponseDto>>  allCalendarRead() {
-
+    public ResponseEntity<ResponseData<CalendarFinalResponseDto>> allCalendarRead() {
 
         List<CalendarResponseDto> calendarResponseDtoList = calendarService.getAllCalendar();
         Long calendarTotalSum = calendarService.getTotalCalendarAmountSum(calendarResponseDtoList);
@@ -39,8 +39,27 @@ public class CalendarController {
     }
 
 
+
+    @GetMapping("/calendar/{calendarId}")
+    public ResponseEntity<ResponseData<CalendarResponseDto>> calendarRead(@PathVariable Long calendarId) {
+
+        CalendarResponseDto dto = calendarService.getCalendarDtoById(calendarId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(
+                        ResponseData.<CalendarResponseDto>builder()
+                                .statusCode(HttpStatus.OK.value())
+                                .data(dto)
+                                .build()
+                );
+    }
+
+
+
     @PostMapping("/home")
-    public ResponseEntity<ResponseData<CalendarResponseDto>> calendarCreate(@RequestBody CalendarRequestDto calendarRequestDto){
+    public ResponseEntity<ResponseData<CalendarResponseDto>> calendarCreate
+            (@RequestBody @Valid CalendarRequestDto calendarRequestDto){
 
         CalendarResponseDto res = calendarService.saveCalendar(calendarRequestDto);
 
@@ -56,12 +75,10 @@ public class CalendarController {
 
 
 
-
-
     @PutMapping("/calendar/update/{calendarId}")
     public ResponseEntity<ResponseData<Void>> calendarUpdate(
             @PathVariable Long calendarId,
-            @RequestBody CalendarUpdateDto calendarUpdateDto){
+            @RequestBody @Valid CalendarUpdateDto calendarUpdateDto){
 
         calendarService.updateCalendar(calendarId, calendarUpdateDto);
 

--- a/src/main/java/com/yoda/accountProject/calendar/domain/Calendar.java
+++ b/src/main/java/com/yoda/accountProject/calendar/domain/Calendar.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,17 +24,19 @@ public class Calendar {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "calendar", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CalendarItem> calendarItemList = new ArrayList<>();
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 35)
     private String title;
 
+    // 현재 애플리케이션 단계에서는 9999-12-31 이하 제약을 어노테이션으로 걸기 어렵기때문에,
+    // schema.sql로 9999-12-31 이하의 DB 컬럼 제약을 걸어놓은 상태이다.
     @Column(nullable = false)
-    private String date;
+    private LocalDate date;
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
     @Builder
-    public Calendar(String title, String date) {
+    public Calendar(String title, LocalDate date) {
         this.title = title;
         this.date = date;
         this.createdAt = LocalDateTime.now();

--- a/src/main/java/com/yoda/accountProject/calendar/dto/CalendarRequestDto.java
+++ b/src/main/java/com/yoda/accountProject/calendar/dto/CalendarRequestDto.java
@@ -1,11 +1,15 @@
 package com.yoda.accountProject.calendar.dto;
 
 import com.yoda.accountProject.calendar.domain.Calendar;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.data.annotation.CreatedBy;
+
+import java.time.LocalDate;
 
 
 @Getter
@@ -13,11 +17,19 @@ import org.springframework.data.annotation.CreatedBy;
 @NoArgsConstructor
 public class CalendarRequestDto {
 
+    @NotNull
+    @Size(max = 35, message = "달력명은 35자 이하여야 합니다.")
     private String title;
-    private String date;
+
+    @NotNull
+    private LocalDate date;
+
+    @AssertTrue(message = "달력 날짜는 9999-12-31 이하여야 합니다.")
+    public boolean isValidDate() {
+        return date == null || !date.isAfter(LocalDate.of(9999, 12, 31));
+    }
 
     public static Calendar toEntity(CalendarRequestDto calendarRequestDto){
-
         return Calendar.builder()
                 .date(calendarRequestDto.getDate())
                 .title(calendarRequestDto.getTitle())
@@ -25,7 +37,7 @@ public class CalendarRequestDto {
     }
 
     @Builder
-    public CalendarRequestDto(String title, String date) {
+    public CalendarRequestDto(String title, LocalDate date) {
         this.title = title;
         this.date = date;
     }

--- a/src/main/java/com/yoda/accountProject/calendar/dto/CalendarResponseDto.java
+++ b/src/main/java/com/yoda/accountProject/calendar/dto/CalendarResponseDto.java
@@ -5,12 +5,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDate;
+
 @Getter
 @Setter
 public class CalendarResponseDto {
 
     private Long id;
-    private String date;
+    private LocalDate date;
     private String title;
     private Long totalAmount = 0L;
 
@@ -23,7 +25,7 @@ public class CalendarResponseDto {
     }
 
     @Builder
-    public CalendarResponseDto(Long id, String date, String title) {
+    public CalendarResponseDto(Long id, LocalDate date, String title) {
         this.id = id;
         this.date = date;
         this.title = title;

--- a/src/main/java/com/yoda/accountProject/calendar/dto/CalendarUpdateDto.java
+++ b/src/main/java/com/yoda/accountProject/calendar/dto/CalendarUpdateDto.java
@@ -1,9 +1,14 @@
 package com.yoda.accountProject.calendar.dto;
 
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.time.LocalDate;
 
 
 @Getter
@@ -11,12 +16,20 @@ import lombok.Setter;
 @NoArgsConstructor
 public class CalendarUpdateDto {
 
+    @NotNull
+    @Size(max = 35, message = "달력명은 35자 이하여야 합니다.")
     private String title;
 
-    private String date;
+    @NotNull
+    private LocalDate date;
+
+    @AssertTrue(message = "달력 날짜는 9999-12-31 이하여야 합니다.")
+    public boolean isValidDate() {
+        return date == null || !date.isAfter(LocalDate.of(9999, 12, 31));
+    }
 
     @Builder
-    public CalendarUpdateDto(String title, String date) {
+    public CalendarUpdateDto(String title, LocalDate date) {
         this.title = title;
         this.date = date;
     }

--- a/src/main/java/com/yoda/accountProject/calendarItem/domain/CalendarItem.java
+++ b/src/main/java/com/yoda/accountProject/calendarItem/domain/CalendarItem.java
@@ -27,7 +27,13 @@ public class CalendarItem {
     @JoinColumn(name = "item_type_id", nullable = false)
     private ItemType itemType;
 
+    @Column(nullable = false, length = 45)
     private String itemTitle;
+
+
+    // 현재 애플리케이션 단계에서는 999_999_999_999 이하 제약을 어노테이션으로 걸기 어렵기때문에,
+    // schema.sql로 999_999_999_999 이하의 DB 컬럼 제약을 걸어놓은 상태이다.
+    @Column(nullable = false)
     private Long itemAmount;
 
     private LocalDateTime createdAt;

--- a/src/main/java/com/yoda/accountProject/calendarItem/domain/Type.java
+++ b/src/main/java/com/yoda/accountProject/calendarItem/domain/Type.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public enum Type {
 
-    // 이때 html 라디오버튼의 name과 객체명이 같아아, 컨트롤러의 모델어트리뷰트에서도 잘 매핑됨
+    // 이때 html 라디오버튼의 name과 객체명이 같아아, 컨트롤러에서도 잘 매핑됨
     EXPENSE(1),
     INCOME(2);
 

--- a/src/main/java/com/yoda/accountProject/calendarItem/dto/CalendarItemFinalResponseDto.java
+++ b/src/main/java/com/yoda/accountProject/calendarItem/dto/CalendarItemFinalResponseDto.java
@@ -1,0 +1,21 @@
+package com.yoda.accountProject.calendarItem.dto;
+
+import com.yoda.accountProject.calendar.dto.CalendarResponseDto;
+import lombok.Getter;
+import lombok.Setter;
+import java.util.List;
+
+@Getter
+@Setter
+public class CalendarItemFinalResponseDto {
+
+    private CalendarResponseDto calendarResponseDto;
+    private List<CalendarItemResponseDto> calendarItemResponseDtoList;
+    private CalendarItemTotalAmountDto totalAmountDto;
+
+    public CalendarItemFinalResponseDto(CalendarResponseDto calendarResponseDto, List<CalendarItemResponseDto> calendarItemResponseDtoList, CalendarItemTotalAmountDto totalAmountDto) {
+        this.calendarResponseDto = calendarResponseDto;
+        this.calendarItemResponseDtoList = calendarItemResponseDtoList;
+        this.totalAmountDto = totalAmountDto;
+    }
+}

--- a/src/main/java/com/yoda/accountProject/calendarItem/dto/CalendarItemRegisterDto.java
+++ b/src/main/java/com/yoda/accountProject/calendarItem/dto/CalendarItemRegisterDto.java
@@ -4,6 +4,9 @@ import com.yoda.accountProject.calendar.domain.Calendar;
 import com.yoda.accountProject.calendarItem.domain.CalendarItem;
 import com.yoda.accountProject.calendarItem.domain.Type;
 import com.yoda.accountProject.itemType.domain.ItemType;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,8 +17,15 @@ import lombok.Setter;
 @NoArgsConstructor
 public class CalendarItemRegisterDto {
 
+    @NotNull
+    @Size(max = 45, message = "항목명은 45자 이하여야 합니다.")
     private String itemTitle;
+
+    @NotNull
+    @Max(value = 999_999_999_999L, message = "허용 가능 금액을 초과하였습니다.")
     private Long itemAmount;
+
+    @NotNull
     private Type type;
 
     @Builder

--- a/src/main/java/com/yoda/accountProject/calendarItem/dto/CalendarItemUpdateDto.java
+++ b/src/main/java/com/yoda/accountProject/calendarItem/dto/CalendarItemUpdateDto.java
@@ -1,8 +1,9 @@
 package com.yoda.accountProject.calendarItem.dto;
 
-import com.yoda.accountProject.calendar.domain.Calendar;
-import com.yoda.accountProject.calendarItem.domain.CalendarItem;
 import com.yoda.accountProject.calendarItem.domain.Type;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,8 +14,15 @@ import lombok.Setter;
 @NoArgsConstructor
 public class CalendarItemUpdateDto {
 
+    @NotNull
+    @Size(max = 45, message = "항목명은 45자 이하여야 합니다.")
     private String itemTitle;
+
+    @NotNull
+    @Max(value = 999_999_999_999L, message = "허용 가능 금액을 초과하였습니다.")
     private Long itemAmount;
+
+    @NotNull
     private Type type;
 
     @Builder

--- a/src/main/java/com/yoda/accountProject/calendarItem/service/impl/CalendarItemServiceImpl.java
+++ b/src/main/java/com/yoda/accountProject/calendarItem/service/impl/CalendarItemServiceImpl.java
@@ -16,7 +16,6 @@ import com.yoda.accountProject.system.exception.calendar.CalendarNotFoundExcepti
 import com.yoda.accountProject.system.exception.calendarItem.CalendarItemNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,9 +58,7 @@ public class CalendarItemServiceImpl implements CalendarItemService {
         CalendarItem entity = calendarItemRepository.findById(calendarItemId)
                 .orElseThrow(() -> new CalendarItemNotFoundException(ExceptionMessage.CalendarItem.CALENDAR_ITEM_NOT_FOUND_ERROR));
 
-        CalendarItemResponseDto calendarItemResponseDto = CalendarItemResponseDto.fromEntity(entity);
-
-        return calendarItemResponseDto;
+        return CalendarItemResponseDto.fromEntity(entity);
 
     }
 

--- a/src/main/java/com/yoda/accountProject/itemType/controller/ItemTypeController.java
+++ b/src/main/java/com/yoda/accountProject/itemType/controller/ItemTypeController.java
@@ -4,10 +4,13 @@ import com.yoda.accountProject.itemType.service.ItemTypeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 
 @Slf4j
-@Controller
+@RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class ItemTypeController {
 

--- a/src/main/java/com/yoda/accountProject/system/exception/ExceptionMessage.java
+++ b/src/main/java/com/yoda/accountProject/system/exception/ExceptionMessage.java
@@ -5,18 +5,18 @@ public class ExceptionMessage {
 
     public static class Calendar {
 
-        public static final String CALENDAR_NOT_FOUND_ERROR = "가계부 달력이 존재하지 않습니다.";
+        public static final String CALENDAR_NOT_FOUND_ERROR = "해당 가계부 달력이 존재하지 않습니다.";
 
     }
 
 
     public static class CalendarItem {
 
-        public static final String CALENDAR_ITEM_NOT_FOUND_ERROR = "해당 세부 항목이 존재하지 않습니다.";
+        public static final String CALENDAR_ITEM_NOT_FOUND_ERROR = "해당 항목이 존재하지 않습니다.";
 
     }
 
-    //
+
     public static class ItemType {
 
         public static final String ITEM_TYPE_NOT_FOUND_ERROR = "해당 항목 종류가 존재하지 않습니다.";

--- a/src/main/java/com/yoda/accountProject/system/exception/calendar/CalendarNotFoundException.java
+++ b/src/main/java/com/yoda/accountProject/system/exception/calendar/CalendarNotFoundException.java
@@ -1,5 +1,9 @@
 package com.yoda.accountProject.system.exception.calendar;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class CalendarNotFoundException extends RuntimeException {
     public CalendarNotFoundException(String message) {
         super(message);

--- a/src/main/java/com/yoda/accountProject/system/exception/calendarItem/CalendarItemNotFoundException.java
+++ b/src/main/java/com/yoda/accountProject/system/exception/calendarItem/CalendarItemNotFoundException.java
@@ -1,5 +1,9 @@
 package com.yoda.accountProject.system.exception.calendarItem;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class CalendarItemNotFoundException extends RuntimeException {
     public CalendarItemNotFoundException(String message) {
         super(message);

--- a/src/main/java/com/yoda/accountProject/system/exception/itemType/ItemTypeNotFoundException.java
+++ b/src/main/java/com/yoda/accountProject/system/exception/itemType/ItemTypeNotFoundException.java
@@ -1,5 +1,9 @@
 package com.yoda.accountProject.system.exception.itemType;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class ItemTypeNotFoundException extends RuntimeException {
 
     public ItemTypeNotFoundException(String message) {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,5 @@
+ALTER TABLE calendar
+    ADD CONSTRAINT check_calendar_date_max CHECK (date <= '9999-12-31');
+
+ALTER TABLE calendar_item
+    ADD CONSTRAINT check_calendar_item_item_amount_max CHECK (item_amount <= 999999999999);

--- a/src/test/java/com/yoda/accountProject/calendar/service/CalendarServiceImplTest.java
+++ b/src/test/java/com/yoda/accountProject/calendar/service/CalendarServiceImplTest.java
@@ -5,7 +5,6 @@ import com.yoda.accountProject.calendar.domain.Calendar;
 import com.yoda.accountProject.calendar.dto.CalendarRequestDto;
 import com.yoda.accountProject.calendar.dto.CalendarResponseDto;
 import com.yoda.accountProject.calendar.repository.CalendarRepository;
-import com.yoda.accountProject.calendar.service.impl.CalendarServiceImpl;
 import com.yoda.accountProject.system.exception.ExceptionMessage;
 import com.yoda.accountProject.system.exception.calendar.CalendarNotFoundException;
 import lombok.extern.slf4j.Slf4j;
@@ -13,9 +12,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
+import java.time.LocalDate;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Slf4j
@@ -33,9 +31,8 @@ class CalendarServiceImplTest {
     void saveCalendar_method_test1() throws Exception {
 
         // given
-
         CalendarRequestDto reqDto = CalendarRequestDto.builder()
-                .date("2025-01-01")
+                .date(LocalDate.of(2025,01,01))
                 .title("테스트 제목")
                 .build();
 

--- a/src/test/java/com/yoda/accountProject/calendarItem/service/CalendarItemServiceImplTest.java
+++ b/src/test/java/com/yoda/accountProject/calendarItem/service/CalendarItemServiceImplTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.LocalDate;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -47,7 +49,7 @@ class CalendarItemServiceImplTest {
 
         // given
         CalendarRequestDto reqDto = CalendarRequestDto.builder()
-                .date("2025-01-01")
+                .date(LocalDate.of(2025,01,01))
                 .title("테스트1")
                 .build();
 


### PR DESCRIPTION
ResponseData 로 구현 / 모든 도메인의 Controller, Service 층 메서드를 수정 및 정리 /
Calendar 엔티티의 date 변수 타입을 LocalDate로 변경 /
유효성 검사, DB 제약 사항 설정 완료 (모든 도메인(Calendar, CalendarItem, ItemType)에 대한 애플리케이션 단계에서 dto에 @Valid 설정 및 schema.sql 파일 추가) /
커스텀 에러 객체에 @ResponseStatus(HttpStatus...) 설정으로 status 코드 조정 완료 /
@RequestMapping("/api") 추가로 fetch 맵핑 시작을 "/api" 로 통일